### PR TITLE
Fixes for compression corruption

### DIFF
--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -14,6 +14,8 @@
 
 #include <stdlib.h>
 #include <zlib.h>
+#include <string.h>
+#include <stdio.h>
 
 /*
 	CompressData
@@ -23,21 +25,26 @@
 */
 int CompressData( char *inPtr, int inSize, char *outPtr)
 {
+	// Don't try to compress 0 sized arrays
+	if( inSize == 0 ) return 0;
+
 	char *_tmpBuffer = (char*) malloc( inSize );
 
 	char *t1 = _tmpBuffer;
 	char *t2 = _tmpBuffer + (inSize + 1) / 2;
 	const char *stop = inPtr + inSize;
 
+	char *inIterate = inPtr;
+
 	while (true)
 	{
-		if (inPtr < stop)
-			*(t1++) = *(inPtr++);
+		if (inIterate < stop)
+			*(t1++) = *(inIterate++);
 		else
 			break;
 
-		if (inPtr < stop)
-			*(t2++) = *(inPtr++);
+		if (inIterate < stop)
+			*(t2++) = *(inIterate++);
 		else
 			break;
 	}
@@ -62,5 +69,18 @@ int CompressData( char *inPtr, int inSize, char *outPtr)
 
 	free( _tmpBuffer );
 
-	return Z_OK == cstatus ? outSize : 0;
+	if( cstatus == Z_OK )
+	{
+		return outSize;
+	}
+
+	// A buffer error means that the data cannot be compressed ( the compressed version is larger than the original )
+	// In this case, OpenEXR dictates that we write the original data
+	// Any other error is unexpected.
+	if( cstatus != Z_BUF_ERROR )  printf( "UNEXPECTED ERROR WRITING DEEP EXR\n" );
+
+	memcpy( outPtr, inPtr, inSize );
+
+	return inSize;
 }
+

--- a/src/exrfile.cpp
+++ b/src/exrfile.cpp
@@ -98,6 +98,8 @@ int EXRFile::OpenOutputFile(const char* i_fileName)
 	m_blocks += height % m_scanline_block->NumLinesInBlock() > 0;
 
 	m_offset_table = new uint64_t [m_blocks];
+	// Initialize table to 0, so that valgrind doesn't complain about writing it out to file before we initialize it
+	for( int i = 0; i < m_blocks; i++ ) m_offset_table[i] = 0;
 	m_offset_table_counter = 0;
 	
 	WriteMagic();


### PR DESCRIPTION
Turns out that the fix for my corruption problems is fairly simple - if the compressed data can't fit into an output buffer the same size as the original data, then the exr convention is to use the original data instead.

I haven't actually compiled this in this exact form, since our local copy of microexr has gotten a bit mangled for namespace reasons, and my only unit tests are part of a more complicated framework, but it definitely fixes the problem in the situations I've tested in.  ( It's better than returning a zero length buffer anyway, which was resulting in writing random data into the image. )
